### PR TITLE
feat: Add VRF inlinePayload option to force inline data URI for on-ch…

### DIFF
--- a/docker/config.production.json
+++ b/docker/config.production.json
@@ -68,5 +68,8 @@
     "enabled": true,
     "cronIntervalMs": 60000,
     "syncPeriodMs": 60000
+  },
+  "vrf": {
+    "inlinePayload": true
   }
 }

--- a/src/services/agent-instance.ts
+++ b/src/services/agent-instance.ts
@@ -136,7 +136,7 @@ export class AgentInstance extends EventEmitter {
             const vrfInline = !!this.config.vrf?.inlinePayload;
             const encodeOptions = vrfInline ? { storage: 'data' as const } : {};
             const result = await this.payloadResolver.encode(content, encodeOptions);
-            console.log(`  🔄 payloadEncoder result URI: ${result.uri.substring(0, 50)}...${vrfInline ? ' (VRF inline forced)' : ''}`);
+            logger.info(`  🔄 payloadEncoder result URI: ${result.uri.substring(0, 50)}...${vrfInline ? ' (VRF inline forced)' : ''}`);
             // Convert URI to bytes (hex-encoded) for on-chain submission if not already encoded
             // The @noosphere/agent-core PayloadResolver may return bytes (0x...) or plain string
             let uri = result.uri;

--- a/src/services/agent-instance.ts
+++ b/src/services/agent-instance.ts
@@ -132,8 +132,11 @@ export class AgentInstance extends EventEmitter {
           // Payload encoder for IPFS upload (uses PayloadResolver)
           payloadEncoder: async (content: string) => {
             console.log(`  🔄 payloadEncoder called, content length: ${content.length}`);
-            const result = await this.payloadResolver.encode(content);
-            console.log(`  🔄 payloadEncoder result URI: ${result.uri.substring(0, 50)}...`);
+            // VRF output must stay inline for on-chain base64 decoding (_decodeRevealOutput)
+            const vrfInline = !!this.config.vrf?.inlinePayload;
+            const encodeOptions = vrfInline ? { storage: 'data' as const } : {};
+            const result = await this.payloadResolver.encode(content, encodeOptions);
+            console.log(`  🔄 payloadEncoder result URI: ${result.uri.substring(0, 50)}...${vrfInline ? ' (VRF inline forced)' : ''}`);
             // Convert URI to bytes (hex-encoded) for on-chain submission if not already encoded
             // The @noosphere/agent-core PayloadResolver may return bytes (0x...) or plain string
             let uri = result.uri;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -116,6 +116,7 @@ export interface VRFConfig {
   retryAttempts?: number;             // Retry attempts for failed operations (default: 3)
   retryDelayMs?: number;              // Delay between retries in ms (default: 10000)
   pollingIntervalMs?: number;         // Fallback polling interval for epoch check (default: 60000)
+  inlinePayload?: boolean;            // Force inline data URI for VRF output (no off-chain upload, default: false)
 }
 
 export interface VRFStatus {


### PR DESCRIPTION
…ain decoding

NoosphereVRFConsumer._decodeRevealOutput() requires data:;base64 prefix for on-chain base64 decoding. When PayloadResolver uploads output to S3 (uploadThreshold < content size), the resulting HTTPS URL causes revert.

Add vrf.inlinePayload config option that forces storage:'data' in payloadEncoder, bypassing S3 upload for VRF container output.