### PR TITLE
feat: Add mainnet support and VRF SDK consistency

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,9 +27,8 @@ config*.json
 !config.example.json
 !config.docker.json.example
 agents.json
-*.keystore.json
-.noosphere/
-.noosphere-e2e/
+**/*.keystore.json
+.noosphere*/
 
 # =============================================================================
 # Development files (not needed in production)

--- a/config.mainnet.json
+++ b/config.mainnet.json
@@ -77,7 +77,7 @@
   },
   "vrf": {
     "enabled": true,
-    "vrfAddress": "0xFd3Fc50bC7b798eDFfCFaB948A1Fd1d614fDA24c",
+    "vrfAddress": "0x6d179D718C7B772CA0d6f694308fb22A516a6eFf",
     "vrngContainerUrl": "http://localhost:8085",
     "autoRegisterEpoch": true,
     "epochLowThreshold": 100,

--- a/config.mainnet.json
+++ b/config.mainnet.json
@@ -1,8 +1,4 @@
 {
-  "payload": {
-    "defaultStorage": "s3",
-    "uploadThreshold": 256
-  },
   "chain": {
     "enabled": true,
     "chainId": 190415,
@@ -11,10 +7,10 @@
     "routerAddress": "0x043F992d67dE8c86141EA5e0897b5244cD97dac4",
     "coordinatorAddress": "0x8b4951d0C2B15Ef4DE1f355e132A40Ac6c84E728",
     "deploymentBlock": 185172,
-    "processingInterval": 10000,
+    "processingInterval": 5000,
     "wallet": {
-      "keystorePath": "/app/.noosphere/keystore.json",
-      "paymentAddress": "0x0000000000000000000000000000000000000000"
+      "keystorePath": "./.noosphere/keystore.mainnet.json",
+      "paymentAddress": "0x11Ea5422FD8b63974B7cF433B2c36fdDfde7B8B9"
     }
   },
   "containers": [
@@ -51,7 +47,7 @@
       "image": "ghcr.io/hpp-io/example-vrng-noosphere:latest",
       "port": "8085",
       "env": {
-        "MASTER_SECRET": "${MASTER_SECRET}"
+        "MASTER_SECRET": "${MAINNET_MASTER_SECRET}"
       }
     }
   ],
@@ -82,7 +78,7 @@
   "vrf": {
     "enabled": true,
     "vrfAddress": "0xFd3Fc50bC7b798eDFfCFaB948A1Fd1d614fDA24c",
-    "vrngContainerUrl": "http://noosphere-vrng:8085",
+    "vrngContainerUrl": "http://localhost:8085",
     "autoRegisterEpoch": true,
     "epochLowThreshold": 100,
     "pollingIntervalMs": 60000,

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -41,6 +41,7 @@ function substituteEnvVars(obj: any): any {
 export interface AgentConfig {
   chain: {
     enabled: boolean;
+    chainId?: number;
     rpcUrl: string;
     wsRpcUrl: string | null;
     routerAddress: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.0.0",
         "@noosphere/agent-core": "0.2.1-alpha.1",
-        "@noosphere/contracts": "0.2.1-alpha.1",
+        "@noosphere/contracts": "^0.2.2-alpha.1",
         "@noosphere/crypto": "0.2.1-alpha.1",
         "@noosphere/payload": "0.2.1-alpha.1",
         "@noosphere/registry": "0.2.1-alpha.1",
@@ -2557,10 +2557,19 @@
         }
       }
     },
-    "node_modules/@noosphere/contracts": {
+    "node_modules/@noosphere/agent-core/node_modules/@noosphere/contracts": {
       "version": "0.2.1-alpha.1",
       "resolved": "https://registry.npmjs.org/@noosphere/contracts/-/contracts-0.2.1-alpha.1.tgz",
       "integrity": "sha512-Yx5L2RdM2hO6HOiThJ6QUUln86kpfiw8C2DDHtBqwXZXZn6tfLR7SdXBybfJ4E9uFWIqsFCjyztn7NBpOlHDEg==",
+      "license": "MIT",
+      "dependencies": {
+        "ethers": "^6.13.0"
+      }
+    },
+    "node_modules/@noosphere/contracts": {
+      "version": "0.2.2-alpha.1",
+      "resolved": "https://registry.npmjs.org/@noosphere/contracts/-/contracts-0.2.2-alpha.1.tgz",
+      "integrity": "sha512-OLkKygWVIaoEHu/FYFvr7Wor0GMO7+Rkab+3qzSQY9tds5kMFyE4kohfnp94gDqvmTUlxNRTZFp6jfL5iieE0w==",
       "license": "MIT",
       "dependencies": {
         "ethers": "^6.13.0"
@@ -2573,6 +2582,15 @@
       "license": "MIT",
       "dependencies": {
         "@noosphere/contracts": "0.2.1-alpha.1",
+        "ethers": "^6.13.0"
+      }
+    },
+    "node_modules/@noosphere/crypto/node_modules/@noosphere/contracts": {
+      "version": "0.2.1-alpha.1",
+      "resolved": "https://registry.npmjs.org/@noosphere/contracts/-/contracts-0.2.1-alpha.1.tgz",
+      "integrity": "sha512-Yx5L2RdM2hO6HOiThJ6QUUln86kpfiw8C2DDHtBqwXZXZn6tfLR7SdXBybfJ4E9uFWIqsFCjyztn7NBpOlHDEg==",
+      "license": "MIT",
+      "dependencies": {
         "ethers": "^6.13.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.0.0",
     "@noosphere/agent-core": "0.2.1-alpha.1",
-    "@noosphere/contracts": "0.2.1-alpha.1",
+    "@noosphere/contracts": "^0.2.2-alpha.1",
     "@noosphere/crypto": "0.2.1-alpha.1",
     "@noosphere/payload": "0.2.1-alpha.1",
     "@noosphere/registry": "0.2.1-alpha.1",

--- a/scripts/generate-config.ts
+++ b/scripts/generate-config.ts
@@ -3,7 +3,8 @@
  * CLI tool to generate config.json from registry
  *
  * Usage:
- *   npm run generate:config                    # Interactive mode - select containers
+ *   npm run generate:config                    # Interactive mode (testnet default)
+ *   npm run generate:config -- --network mainnet  # Mainnet config
  *   npm run generate:config -- --list          # List available containers
  *   npm run generate:config -- --all           # Add all containers
  *   npm run generate:config -- --containers noosphere-hello-world,noosphere-llm
@@ -13,8 +14,46 @@ import fs from 'fs';
 import path from 'path';
 import readline from 'readline';
 
-const REGISTRY_URL = 'https://raw.githubusercontent.com/hpp-io/noosphere-registry/main/registry.json';
-const CONFIG_TEMPLATE_PATH = './config.template.json';
+interface NetworkPreset {
+  chainId: number;
+  rpcUrl: string;
+  wsRpcUrl: string;
+  routerAddress: string;
+  coordinatorAddress: string;
+  deploymentBlock: number;
+  verifierAddress: string;
+  proofServiceImage: string;
+  vrfAddress: string;
+  registryUrl: string;
+}
+
+const NETWORK_PRESETS: Record<string, NetworkPreset> = {
+  testnet: {
+    chainId: 181228,
+    rpcUrl: 'https://sepolia.hpp.io',
+    wsRpcUrl: 'wss://sepolia.hpp.io',
+    routerAddress: '0x480a4f7506548773040d47dd7b6372dbf71358d4',
+    coordinatorAddress: '0xeda4a7957e8f5de6cd6bd747c3ccd5e1c295302c',
+    deploymentBlock: 10520,
+    verifierAddress: '0x672c325941E3190838523052ebFF122146864EAd',
+    proofServiceImage: 'ghcr.io/hpp-io/noosphere-proof-creator:dev',
+    vrfAddress: '0xb49Cf5e93A225638cD7fa8e4479149f453AE2e39',
+    registryUrl: 'https://raw.githubusercontent.com/hpp-io/noosphere-registry/main/networks/181228.json',
+  },
+  mainnet: {
+    chainId: 190415,
+    rpcUrl: 'https://mainnet.hpp.io',
+    wsRpcUrl: 'wss://mainnet.hpp.io',
+    routerAddress: '0x043F992d67dE8c86141EA5e0897b5244cD97dac4',
+    coordinatorAddress: '0x8b4951d0C2B15Ef4DE1f355e132A40Ac6c84E728',
+    deploymentBlock: 185172,
+    verifierAddress: '0xFF46177E5210A8dc31E98477295d6A91510d67a0',
+    proofServiceImage: 'ghcr.io/hpp-io/noosphere-proof-creator:latest',
+    vrfAddress: '0xFd3Fc50bC7b798eDFfCFaB948A1Fd1d614fDA24c',
+    registryUrl: 'https://raw.githubusercontent.com/hpp-io/noosphere-registry/main/networks/190415.json',
+  },
+};
+
 const CONFIG_OUTPUT_PATH = './config.json';
 
 interface RegistryContainer {
@@ -46,9 +85,9 @@ interface Registry {
   version: string;
 }
 
-async function fetchRegistry(): Promise<Registry> {
-  console.log('📡 Fetching registry from', REGISTRY_URL);
-  const response = await fetch(REGISTRY_URL);
+async function fetchRegistry(registryUrl: string): Promise<Registry> {
+  console.log('📡 Fetching registry from', registryUrl);
+  const response = await fetch(registryUrl);
   if (!response.ok) {
     throw new Error(`Failed to fetch registry: ${response.status}`);
   }
@@ -127,15 +166,16 @@ function generateContainerConfig(hashId: string, container: RegistryContainer): 
   return config;
 }
 
-function generateConfig(selectedContainers: ConfigContainer[]): object {
+function generateConfig(selectedContainers: ConfigContainer[], network: NetworkPreset): object {
   return {
     chain: {
       enabled: true,
-      rpcUrl: 'https://sepolia.hpp.io',
-      wsRpcUrl: 'wss://sepolia.hpp.io',
-      routerAddress: '0x31B0d4038b65E2c17c769Bad1eEeA18EEb1dBdF6',
-      coordinatorAddress: '0x5e055cd47e5d16f3645174cfe2423d61fe8f4585',
-      deploymentBlock: 7776,
+      chainId: network.chainId,
+      rpcUrl: network.rpcUrl,
+      wsRpcUrl: network.wsRpcUrl,
+      routerAddress: network.routerAddress,
+      coordinatorAddress: network.coordinatorAddress,
+      deploymentBlock: network.deploymentBlock,
       processingInterval: 5000,
       wallet: {
         keystorePath: './.noosphere/keystore.json',
@@ -147,16 +187,16 @@ function generateConfig(selectedContainers: ConfigContainer[]): object {
       {
         id: 'immediate-finalize-verifier',
         name: 'Immediate Finalize Verifier',
-        address: '0x672c325941E3190838523052ebFF122146864EAd',
+        address: network.verifierAddress,
         requiresProof: true,
         proofService: {
-          image: 'ghcr.io/hpp-io/noosphere-proof-creator:dev',
+          image: network.proofServiceImage,
           port: '3001',
           command: 'npm start',
           env: {
-            RPC_URL: 'https://sepolia.hpp.io',
-            CHAIN_ID: '181228',
-            IMMEDIATE_FINALIZE_VERIFIER_ADDRESS: '0x672c325941E3190838523052ebFF122146864EAd',
+            RPC_URL: network.rpcUrl,
+            CHAIN_ID: network.chainId.toString(),
+            IMMEDIATE_FINALIZE_VERIFIER_ADDRESS: network.verifierAddress,
             PRIVATE_KEY: '${PROOF_SERVICE_PRIVATE_KEY}',
           },
         },
@@ -167,8 +207,13 @@ function generateConfig(selectedContainers: ConfigContainer[]): object {
       cronIntervalMs: 60000,
       syncPeriodMs: 3000,
     },
-    logging: {
-      level: 'info',
+    vrf: {
+      enabled: false,
+      vrfAddress: network.vrfAddress,
+      vrngContainerUrl: 'http://localhost:8085',
+      autoRegisterEpoch: true,
+      epochLowThreshold: 100,
+      pollingIntervalMs: 60000,
     },
   };
 }
@@ -221,11 +266,25 @@ async function interactiveMode(registry: Registry): Promise<ConfigContainer[]> {
   return selectedContainers;
 }
 
+function parseNetwork(args: string[]): NetworkPreset {
+  const networkIdx = args.indexOf('--network');
+  const networkName = networkIdx >= 0 ? args[networkIdx + 1] : 'testnet';
+
+  const preset = NETWORK_PRESETS[networkName];
+  if (!preset) {
+    throw new Error(`Unknown network: ${networkName}. Available: ${Object.keys(NETWORK_PRESETS).join(', ')}`);
+  }
+
+  console.log(`🌐 Network: ${networkName} (chainId: ${preset.chainId})`);
+  return preset;
+}
+
 async function main() {
   const args = process.argv.slice(2);
 
   try {
-    const registry = await fetchRegistry();
+    const network = parseNetwork(args);
+    const registry = await fetchRegistry(network.registryUrl);
 
     // --list: List available containers
     if (args.includes('--list')) {
@@ -270,7 +329,7 @@ async function main() {
     }
 
     // Generate config
-    const config = generateConfig(selectedContainers);
+    const config = generateConfig(selectedContainers, network);
 
     // Check if config.json exists
     const outputPath = args.includes('--output')

--- a/scripts/setup-agent-wallet.ts
+++ b/scripts/setup-agent-wallet.ts
@@ -16,8 +16,11 @@ loadEnv();
 async function main() {
   console.log('🔐 Setting up Noosphere Agent Wallet\n');
 
-  // Load configuration from config.json
-  const configPath = path.join(process.cwd(), 'config.json');
+  // Load configuration from config.json (or NOOSPHERE_CONFIG_PATH)
+  const configPath = process.env.NOOSPHERE_CONFIG_PATH
+    ? path.resolve(process.env.NOOSPHERE_CONFIG_PATH)
+    : path.join(process.cwd(), 'config.json');
+  console.log(`📄 Config: ${configPath}`);
   const configData = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
 
   // Get secrets from environment variables

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,7 +19,12 @@ let cachedEoaAddress: string | null = null;
 
 async function getGlobalRegistry(): Promise<RegistryManager> {
   if (!cachedRegistry) {
-    cachedRegistry = new RegistryManager({ autoSync: false, cacheTTL: 3600000 });
+    const config = loadConfig();
+    const registryOptions: any = { autoSync: false, cacheTTL: 3600000 };
+    if (config.chain.chainId) {
+      registryOptions.remotePath = `https://raw.githubusercontent.com/hpp-io/noosphere-registry/main/networks/${config.chain.chainId}.json`;
+    }
+    cachedRegistry = new RegistryManager(registryOptions);
     await cachedRegistry.load();
   }
   return cachedRegistry;

--- a/src/app.ts
+++ b/src/app.ts
@@ -20,9 +20,12 @@ let cachedEoaAddress: string | null = null;
 async function getGlobalRegistry(): Promise<RegistryManager> {
   if (!cachedRegistry) {
     const config = loadConfig();
-    const registryOptions: any = { autoSync: false, cacheTTL: 3600000 };
+    const registryOptions: { autoSync: boolean; cacheTTL: number; remotePath?: string } = { autoSync: false, cacheTTL: 3600000 };
     if (config.chain.chainId) {
-      registryOptions.remotePath = `https://raw.githubusercontent.com/hpp-io/noosphere-registry/main/networks/${config.chain.chainId}.json`;
+      const safeChainId = String(config.chain.chainId).replace(/[^0-9]/g, '');
+      if (safeChainId) {
+        registryOptions.remotePath = `https://raw.githubusercontent.com/hpp-io/noosphere-registry/main/networks/${safeChainId}.json`;
+      }
     }
     cachedRegistry = new RegistryManager(registryOptions);
     await cachedRegistry.load();

--- a/src/services/agent-instance.ts
+++ b/src/services/agent-instance.ts
@@ -100,9 +100,12 @@ export class AgentInstance extends EventEmitter {
 
     try {
       // Load registry (per-network file based on chainId)
-      const registryOptions: any = { autoSync: true, cacheTTL: 3600000 };
+      const registryOptions: { autoSync: boolean; cacheTTL: number; remotePath?: string } = { autoSync: true, cacheTTL: 3600000 };
       if (this.config.chain.chainId) {
-        registryOptions.remotePath = `https://raw.githubusercontent.com/hpp-io/noosphere-registry/main/networks/${this.config.chain.chainId}.json`;
+        const safeChainId = String(this.config.chain.chainId).replace(/[^0-9]/g, '');
+        if (safeChainId) {
+          registryOptions.remotePath = `https://raw.githubusercontent.com/hpp-io/noosphere-registry/main/networks/${safeChainId}.json`;
+        }
       }
       this.registry = new RegistryManager(registryOptions);
       await this.registry.load();

--- a/src/services/agent-instance.ts
+++ b/src/services/agent-instance.ts
@@ -99,8 +99,12 @@ export class AgentInstance extends EventEmitter {
     logger.info(`[${this.id}] Initializing agent...`);
 
     try {
-      // Load registry
-      this.registry = new RegistryManager({ autoSync: true, cacheTTL: 3600000 });
+      // Load registry (per-network file based on chainId)
+      const registryOptions: any = { autoSync: true, cacheTTL: 3600000 };
+      if (this.config.chain.chainId) {
+        registryOptions.remotePath = `https://raw.githubusercontent.com/hpp-io/noosphere-registry/main/networks/${this.config.chain.chainId}.json`;
+      }
+      this.registry = new RegistryManager(registryOptions);
       await this.registry.load();
 
       // Build container map

--- a/src/services/agent-manager.ts
+++ b/src/services/agent-manager.ts
@@ -62,11 +62,13 @@ export class AgentManager extends EventEmitter {
       return agents;
     }
 
-    // Fallback to single agent (config.json)
-    const singleConfigPath = path.join(process.cwd(), 'config.json');
+    // Fallback to single agent (NOOSPHERE_CONFIG_PATH or config.json)
+    const singleConfigPath = process.env.NOOSPHERE_CONFIG_PATH
+      ? path.resolve(process.env.NOOSPHERE_CONFIG_PATH)
+      : path.join(process.cwd(), 'config.json');
 
     if (fs.existsSync(singleConfigPath)) {
-      logger.info('Loading single-agent config from config.json');
+      logger.info(`Loading single-agent config from ${singleConfigPath}`);
       return [{
         id: 'default',
         name: 'Default Agent',

--- a/src/services/epoch-manager.ts
+++ b/src/services/epoch-manager.ts
@@ -2,11 +2,7 @@ import { EventEmitter } from 'events';
 import { ethers, Contract, JsonRpcProvider, WebSocketProvider, Wallet } from 'ethers';
 import { logger } from '../../lib/logger';
 import { VRFConfig, VRFStatus } from '../types';
-import * as fs from 'fs';
-import * as path from 'path';
-
-// Load NoosphereVRF ABI
-const VRF_ABI_PATH = path.join(__dirname, '../../abis/NoosphereVRF.json');
+import { ABIs } from '@noosphere/contracts';
 
 /**
  * EpochManager — manages NoosphereVRF epoch lifecycle.
@@ -41,12 +37,7 @@ export class EpochManager extends EventEmitter {
     private wsRpcUrl?: string,
   ) {
     super();
-
-    // Load ABI
-    if (!fs.existsSync(VRF_ABI_PATH)) {
-      throw new Error(`NoosphereVRF ABI not found at ${VRF_ABI_PATH}`);
-    }
-    this.vrfAbi = JSON.parse(fs.readFileSync(VRF_ABI_PATH, 'utf-8'));
+    this.vrfAbi = ABIs.NoosphereVRF;
   }
 
   /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,6 +32,7 @@ export interface AgentManagerStatus {
 
 // Config types
 export interface ChainConfig {
+  chainId?: number;
   rpcUrl: string;
   wsRpcUrl?: string;
   routerAddress: string;


### PR DESCRIPTION
## Summary
- Add mainnet support with per-network config and registry loading (chainId-aware)
- Refactor EpochManager to load NoosphereVRF ABI from `@noosphere/contracts` SDK package instead of local filesystem, consistent with all other contract ABIs
- Update mainnet VRF contract address
- Bump `@noosphere/contracts` to 0.2.2-alpha.1

## Test plan
- [x] Docker build succeeds without local `abis/` directory
- [x] EpochManager initializes correctly with SDK-provided ABI
- [x] VRF epoch management works end-to-end on mainnet
- [x] DiceGame VRF flow verified on HPP Mainnet (chainId 190415)