### PR TITLE
fix: use API route proxy for dashboard to support multi-instance depl…

### DIFF
--- a/app/api/[...path]/route.ts
+++ b/app/api/[...path]/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest } from "next/server";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  const { path } = await params;
+  const search = request.nextUrl.search;
+  const target = `${API_URL}/api/${path.join("/")}${search}`;
+
+  const res = await fetch(target);
+  return new Response(res.body, {
+    status: res.status,
+    headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
+  });
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  const { path } = await params;
+  const search = request.nextUrl.search;
+  const target = `${API_URL}/api/${path.join("/")}${search}`;
+
+  const res = await fetch(target, {
+    method: "POST",
+    headers: { "content-type": request.headers.get("content-type") ?? "application/json" },
+    body: request.body,
+  });
+  return new Response(res.body, {
+    status: res.status,
+    headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
+  });
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,11 +1,13 @@
 // API configuration for frontend
+// Uses relative "/api" path so requests go through the Next.js API route proxy.
+// This ensures correct routing regardless of external port mapping.
 function getApiBaseUrl(): string {
-  // Server-side: use env var or default
   if (typeof window === 'undefined') {
+    // Server-side: direct connection to API server
     return process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
   }
-  // Client-side: use current hostname with API port
-  return `${window.location.protocol}//${window.location.hostname}:4000`;
+  // Client-side: proxy through Next.js API route
+  return '';
 }
 
 export const API_BASE_URL = getApiBaseUrl();


### PR DESCRIPTION
…oyments

Browser requests now go through Next.js API route proxy instead of directly to port 4000. This allows testnet and mainnet agents to run on the same server with different port mappings.